### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.Directory/Frends.Directory.csproj
+++ b/Frends.Directory/Frends.Directory.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="SimpleImpersonation, Version=2.0.1.27158, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleImpersonation.2.0.1\lib\net40-Client\SimpleImpersonation.dll</HintPath>

--- a/Frends.Directory/packages.config
+++ b/Frends.Directory/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="SimpleImpersonation" version="2.0.1" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,20 +1,11 @@
-- [Frends.Directory](#frends.directory)
+- [Frends.Directory](#frendsdirectory)
    - [Installing](#installing)
    - [Building](#building)
    - [Contributing](#contributing)
    - [Documentation](#documentation)
-     - [Directory.Create](#directory.create)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Directory.Move](#directory.move)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Directory.Delete](#directory.delete)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
+     - [Directory.Create](#directorycreate)
+     - [Directory.Move](#directorymove)
+     - [Directory.Delete](#directorydelete) 
    - [License](#license)
 
 # Frends.Directory
@@ -25,7 +16,6 @@ You can install the task via FRENDS UI Task view or you can find the nuget packa
 `https://www.myget.org/F/frends/api/v2`
 
 ## Building
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
 
 Clone a copy of the repo
 

--- a/nuspec/Frends.Directory.nuspec
+++ b/nuspec/Frends.Directory.nuspec
@@ -10,7 +10,6 @@
     <description>FRENDS Directory tasks</description>
     <summary />
     <dependencies>
-	  <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="SimpleImpersonation" version="2.0.1" />
     </dependencies>
     <frameworkAssemblies>
@@ -19,7 +18,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.Directory\bin\Release\Frends.Directory.dll" target="lib\net452\Frends.Directory.dll" />	
+    <file src="Frends.Directory\bin\Release\Frends.Directory.dll" target="lib\net452\Frends.Directory.dll" />
     <file src="Frends.Directory\bin\Release\Frends.Directory.XML" target="Frends.Directory.XML"/>
     <file src="Frends.Directory\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>


### PR DESCRIPTION
Version 1.2.0 from nuget.org cannot be used as it has the wrong assembly version, so compilation will fail.