### PR TITLE
Replaced Frends.tasks.attributes with System.ComponentModel.DataAnnotations

### DIFF
--- a/Frends.Directory/Definitions.cs
+++ b/Frends.Directory/Definitions.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel;
-using Frends.Tasks.Attributes;
+using System.ComponentModel.DataAnnotations;
 #pragma warning disable 1591
 
 namespace Frends.Directory
@@ -23,11 +23,11 @@ namespace Frends.Directory
         /// This needs to be of format domain\username
         /// </summary>
         [DefaultValue("\"domain\\username\"")]
-        [ConditionalDisplay(nameof(UseGivenUserCredentialsForRemoteConnections), true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string UserName { get; set; }
 
         [PasswordPropertyText]
-        [ConditionalDisplay(nameof(UseGivenUserCredentialsForRemoteConnections), true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string Password { get; set; }
     }
     public class DeleteOptions
@@ -48,11 +48,11 @@ namespace Frends.Directory
         /// This needs to be of format domain\username
         /// </summary>
         [DefaultValue("\"domain\\username\"")]
-        [ConditionalDisplay(nameof(UseGivenUserCredentialsForRemoteConnections), true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string UserName { get; set; }
 
         [PasswordPropertyText]
-        [ConditionalDisplay(nameof(UseGivenUserCredentialsForRemoteConnections), true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string Password { get; set; }
     }
 
@@ -88,11 +88,11 @@ namespace Frends.Directory
         /// This needs to be of format domain\username
         /// </summary>
         [DefaultValue("\"domain\\username\"")]
-        [ConditionalDisplay(nameof(UseGivenUserCredentialsForRemoteConnections), true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string UserName { get; set; }
 
         [PasswordPropertyText]
-        [ConditionalDisplay(nameof(UseGivenUserCredentialsForRemoteConnections), true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string Password { get; set; }
     }
 

--- a/Frends.Directory/Directory.cs
+++ b/Frends.Directory/Directory.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Frends.Tasks.Attributes;
+using System.ComponentModel;
 using SimpleImpersonation;
 #pragma warning disable 1591
 
@@ -17,7 +11,7 @@ namespace Frends.Directory
         /// Delete a directory. This task will by default throw if the directory is not empty. If the directory is not found, an empty result is returned. See https://github.com/FrendsPlatform/Frends.Directory
         /// </summary>
         /// <returns>Object { string Path, bool DirectoryNotFound } </returns>
-        public static DeleteResult Delete([CustomDisplay(DisplayOption.Tab)] SharedInput input, [CustomDisplay(DisplayOption.Tab)] DeleteOptions options)
+        public static DeleteResult Delete([PropertyTab] SharedInput input, [PropertyTab] DeleteOptions options)
         {
             if (!options.UseGivenUserCredentialsForRemoteConnections)
             {
@@ -35,7 +29,7 @@ namespace Frends.Directory
         /// Creates all directories and subdirectories in the specified path unless they already exist. Will not do anything if the directory exists. See https://github.com/FrendsPlatform/Frends.Directory
         /// </summary>
         /// <returns>Object { string Path } </returns>
-        public static CreateResult Create([CustomDisplay(DisplayOption.Tab)] SharedInput input, [CustomDisplay(DisplayOption.Tab)] CreateOptions options)
+        public static CreateResult Create([PropertyTab] SharedInput input, [PropertyTab] CreateOptions options)
         {
             if (!options.UseGivenUserCredentialsForRemoteConnections)
             {
@@ -53,7 +47,7 @@ namespace Frends.Directory
         /// Moves a directory. By default will throw an error if the directory already exists. See https://github.com/FrendsPlatform/Frends.Directory
         /// </summary>
         /// <returns>Object { string TargetDirectory, string SourceDirectory }</returns>
-        public static MoveResult Move([CustomDisplay(DisplayOption.Tab)] MoveInput input, [CustomDisplay(DisplayOption.Tab)] MoveOptions options)
+        public static MoveResult Move([PropertyTab] MoveInput input, [PropertyTab] MoveOptions options)
         {
             if (!options.UseGivenUserCredentialsForRemoteConnections)
             {

--- a/Frends.Directory/Frends.Directory.csproj
+++ b/Frends.Directory/Frends.Directory.csproj
@@ -32,14 +32,12 @@
     <DocumentationFile>bin\Release\Frends.Directory.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-    </Reference>
     <Reference Include="SimpleImpersonation, Version=2.0.1.27158, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleImpersonation.2.0.1\lib\net40-Client\SimpleImpersonation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Frends.Directory/packages.config
+++ b/Frends.Directory/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="SimpleImpersonation" version="2.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Replaced usage of custom attributes from Frends.tasks.attributes with their counterparts from System.ComponentModel.DataAnnotations, as the Frends.Tasks.Attributes reference mostly does not work together with older versions